### PR TITLE
Hardcode distinct pronto erblint config

### DIFF
--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -5,7 +5,7 @@ require 'erb_lint/file_loader'
 
 module Pronto
   class ERBLint < Runner
-    DEFAULT_CONFIG_FILENAME = '.erb-lint.yml'
+    DEFAULT_CONFIG_FILENAME = '.erb-lint-pronto.yml'
 
     def initialize(_, _ = nil)
       super

--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -22,10 +22,12 @@ module Pronto
     end
 
     def load_config
+      puts "HERE IN LOAD CONFIG #{config_filename}"
       if File.exist?(config_filename)
         config = ::ERBLint::RunnerConfig.new(file_loader.yaml(config_filename))
         @config = ::ERBLint::RunnerConfig.default.merge(config)
       else
+        puts "USING DEFAULT CONFIG"
         warn "#{config_filename} not found: using default config"
         @config = ::ERBLint::RunnerConfig.default
       end

--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -37,7 +37,7 @@ module Pronto
     end
 
     def config_filename
-      @config_filename ||= @options[:config] || ::ERBLint::CLI::DEFAULT_CONFIG_FILENAME
+      @config_filename ||= @options[:config] || DEFAULT_CONFIG_FILENAME
     end
 
     def file_loader

--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -22,12 +22,10 @@ module Pronto
     end
 
     def load_config
-      puts "HERE IN LOAD CONFIG #{config_filename}"
       if File.exist?(config_filename)
         config = ::ERBLint::RunnerConfig.new(file_loader.yaml(config_filename))
         @config = ::ERBLint::RunnerConfig.default.merge(config)
       else
-        puts "USING DEFAULT CONFIG"
         warn "#{config_filename} not found: using default config"
         @config = ::ERBLint::RunnerConfig.default
       end

--- a/pronto-erb_lint.gemspec
+++ b/pronto-erb_lint.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('erb_lint', '~> 0.1.1')
+  s.add_runtime_dependency('erb_lint', '~> 0.0.24')
   s.add_runtime_dependency('pronto', '> 0.9.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')


### PR DESCRIPTION
we only want to run erbsafety on pronto for now. to do this we need pronto to use a separate erb-lint config from the usual era lint. unfortunately there is no apparent way to pass a parameter to this runner to specify this - so I have hardcoded the distinct filename for pronto's erb lint config 